### PR TITLE
0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.0.5 (2019-04-02)
+==================
+
+* Handle a error: `CREATE TABLE` is not applied.
+* Use `PrestoHook#run` instead of `PrestoHook#get_first` for `{CREATE,DROP} {VIEW,TABLE}`
+
 0.0.4 (2019-03-25)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-plugin-glue_presto_apas"
-version = "0.0.4"
+version = "0.0.5"
 description = "An Airflow Plugin to Add a Partition As Select(APAS) on Presto that uses Glue Data Catalog as a Hive metastore."
 readme = "README.md"
 authors = ["Civitaspo <civitaspo@gmail.com>"]

--- a/src/airflow/operators/glue_presto_apas.py
+++ b/src/airflow/operators/glue_presto_apas.py
@@ -237,6 +237,9 @@ class GluePrestoApasOperator(BaseOperator):
                 prop_stmt = self._prepare_create_table_properties_stmt()
                 presto.get_first(f"CREATE TABLE {self.db}.{tmp_table} ( {','.join(col_stmts)} )"
                                  f"WITH ( {prop_stmt} )")
+                if not glue.does_table_exists(self.db, tmp_table):
+                    raise StateError(f"Run CREATE TABLE, but the table does not exists: {self.db}.{tmp_table}")
+
                 presto.get_first(f"INSERT INTO {self.db}.{tmp_table} {self.sql}")
                 if glue.does_partition_exists(db=self.db,
                                               table_name=self.table,
@@ -264,6 +267,10 @@ class Error(Exception):
 
 
 class ConfigError(Error):
+    pass
+
+
+class StateError(Error):
     pass
 
 

--- a/src/airflow/operators/glue_presto_apas.py
+++ b/src/airflow/operators/glue_presto_apas.py
@@ -183,7 +183,7 @@ class GluePrestoApasOperator(BaseOperator):
             f"_{self._random_str()}"
         columns: List[Dict[str, str]] = []
         try:
-            presto.get_first(f"CREATE VIEW {self.db}.{tmp_table} AS {self.sql}")
+            presto.get_first(f"CREATE VIEW {self.db}.{tmp_table} AS {sql}")
             for c in presto.get_records(f"DESCRIBE {self.db}.{tmp_table}"):
                 col_name = c[0]
                 col_type = c[1]

--- a/src/airflow/operators/glue_presto_apas.py
+++ b/src/airflow/operators/glue_presto_apas.py
@@ -183,7 +183,7 @@ class GluePrestoApasOperator(BaseOperator):
             f"_{self._random_str()}"
         columns: List[Dict[str, str]] = []
         try:
-            presto.get_first(f"CREATE VIEW {self.db}.{tmp_table} AS {sql}")
+            presto.run(f"CREATE VIEW {self.db}.{tmp_table} AS {sql}")
             for c in presto.get_records(f"DESCRIBE {self.db}.{tmp_table}"):
                 col_name = c[0]
                 col_type = c[1]
@@ -192,7 +192,7 @@ class GluePrestoApasOperator(BaseOperator):
                     'type': col_type,
                 })
         finally:
-            presto.get_first(f"DROP VIEW {self.db}.{tmp_table}")
+            presto.run(f"DROP VIEW {self.db}.{tmp_table}")
         return columns
 
     def _prepare_create_table_properties_stmt(self):
@@ -235,12 +235,12 @@ class GluePrestoApasOperator(BaseOperator):
 
             try:
                 prop_stmt = self._prepare_create_table_properties_stmt()
-                presto.get_first(f"CREATE TABLE {self.db}.{tmp_table} ( {','.join(col_stmts)} )"
+                presto.run(f"CREATE TABLE {self.db}.{tmp_table} ( {','.join(col_stmts)} )"
                                  f"WITH ( {prop_stmt} )")
                 if not glue.does_table_exists(self.db, tmp_table):
                     raise StateError(f"Run CREATE TABLE, but the table does not exists: {self.db}.{tmp_table}")
 
-                presto.get_first(f"INSERT INTO {self.db}.{tmp_table} {self.sql}")
+                presto.run(f"INSERT INTO {self.db}.{tmp_table} {self.sql}")
                 if glue.does_partition_exists(db=self.db,
                                               table_name=self.table,
                                               partition_values=ordered_partition_values):


### PR DESCRIPTION
* Handle a error: `CREATE TABLE` is not applied.
* Use `PrestoHook#run` instead of `PrestoHook#get_first` for `{CREATE,DROP} {VIEW,TABLE}`